### PR TITLE
Move from debian:wheezy to debian:jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	0.1
 
-FROM debian:jessie
+FROM debian:jessie-slim
 MAINTAINER Richard North <rich.north@gmail.com>
 
 LABEL Description="This image can be used to create a sidekick container for recording videos of VNC sessions hosted in other containers"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION	0.1
 
-FROM debian:wheezy
+FROM debian:jessie
 MAINTAINER Richard North <rich.north@gmail.com>
 
 LABEL Description="This image can be used to create a sidekick container for recording videos of VNC sessions hosted in other containers"


### PR DESCRIPTION
I experienced an issue related to the usage of debian:wheezy on Docker linux, similar to: https://github.com/moby/moby/issues/34301

Basically debian:wheezy image crashes with a segfault whenever I'm using it. In order to be able to use the vnc-recorder on my machine, I then need it to be based on debian:jessie.

I think it doesn't change anything for the behaviour of vnc-recorder python script.