### PR TITLE
Multi-platform build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,33 @@
+name: Build multi-arch Docker Image
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker info
+      run: docker info
+    - name: Buildx inspect
+      run: docker buildx inspect
+
+    - name: Build image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+        push: false
+        # Use a 'temp' tag, that won't be pushed, for non-release builds
+        tags: testcontainers/ryuk:${{ github.event.release.tag_name || 'temp' }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,39 @@
+name: Release multi-arch Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker info
+      run: docker info
+    - name: Buildx inspect
+      run: docker buildx inspect
+
+    - name: Build and push image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+        # Only push if we are publishing a release
+        push: true
+        tags: testcontainers/ryuk:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL Description="This image can be used to create a sidekick container for rec
 LABEL maintainer="Richard North <rich.north@gmail.com>"
 
 RUN apt-get update && apt-get install -y \
-  python-pip python-dev ffmpeg=7:4.1.6-1~deb10u1 \
+  python-pip python-dev ffmpeg \
   && rm -rf /var/lib/apt/lists/* \
   && pip install vnc2flv \
   && rm -fr /tmp/*


### PR DESCRIPTION
Tweak the Dockerfile so that this will build on other architectures.

Add GitHub workflows based on https://github.com/testcontainers/moby-ryuk/commit/11b883731789977957cf6cf57432df40434f8d15 to build and publish on all architectures.

Post-merge:
1. You'll need to setup the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets in the `vnc-recorder` project like has been done in `moby-ryuk`. You can see an example of the workflows running on a PR here: https://github.com/deejgregor/vnc-recorder/pull/2
2. Tag (or manually build and push) a release. It might be nice to release 1.2.0 again for all archs (or all archs except for amd64). Since there are almost no changes to the Dockerfile I'm not sure if a new version is needed.