### PR TITLE
Make sure Docker tags refer to this project, not ryuk

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -30,4 +30,4 @@ jobs:
         platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
         push: false
         # Use a 'temp' tag, that won't be pushed, for non-release builds
-        tags: testcontainers/ryuk:${{ github.event.release.tag_name || 'temp' }}
+        tags: testcontainers/vnc-recorder:${{ github.event.release.tag_name || 'temp' }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -36,4 +36,4 @@ jobs:
         platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
         # Only push if we are publishing a release
         push: true
-        tags: testcontainers/ryuk:${{ github.event.release.tag_name }}
+        tags: testcontainers/vnc-recorder:${{ github.event.release.tag_name }}


### PR DESCRIPTION
Fix for an issue introduced in #5. Thanks to @mdelapenya for noticing this.

I dig a `git grep ryuk` to make sure there wasn't anything else I missed and there's nothing remaining from ryuk in this repo.