### PR TITLE
chore(deps): add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+        interval: monthly
+        day: sunday
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled
+    - package-ecosystem: docker
+      directory: /
+      schedule:
+        interval: monthly


### PR DESCRIPTION
Adds dependabot manifest for:
- Dockerfile
- Github actions

It will run in a monthly basis, on Sundays.
